### PR TITLE
Add end-of-life note to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
+# :warning: This project is currently unmaintained
+
+This client is not up to date with the latest Giphy API version and is unlikely to receive support in the future.
+
+Alternatives include:
+
+- SDKs documented on our Developer site: https://developers.giphy.com/docs/sdk/
+- Directly performing API calls, see: https://developers.giphy.com/docs/api
+- Third-party-libraries
+
+
 # Giphy Core Client for Python
 
-
 The **Giphy Core SDK** is a wrapper around [Giphy API](https://github.com/Giphy/GiphyAPI).
-
-[![Build Status](https://travis-ci.com/Giphy/giphy-python-client.svg?token=ytpQbMSuy8sydsqZwbwp&branch=master)](https://travis-ci.com/Giphy/giphy-python-client)
 
 [Giphy](https://www.giphy.com) is the best way to search, share, and discover GIFs on the Internet. Similar to the way other search engines work, the majority of our content comes from indexing based on the best and most popular GIFs and search terms across the web. We organize all those GIFs so you can find the good content easier and share it out through your social channels. We also feature some of our favorite GIF artists and work with brands to create and promote their original GIF content.
 


### PR DESCRIPTION
As described in https://github.com/Giphy/giphy-python-client/issues/5#issuecomment-964291632 by @ethanlu, this client is not going to be supported anymore.

Since this package comes from the official @Giphy organization, it is given the impression that it works unless explicitly stated otherwise.

So I suggest to update the README and set the repository to "archived" to point out that users should look for alternatives.

Thanks a lot in advance for your feedback!